### PR TITLE
Enable Python tools in Docker Image

### DIFF
--- a/ev3dev-stretch/debian-stretch-cross-pytools.dockerfile
+++ b/ev3dev-stretch/debian-stretch-cross-pytools.dockerfile
@@ -1,0 +1,7 @@
+FROM ev3dev:debian-stretch-cross
+
+# Install python tools needed for cross builds
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        python \
+        scons

--- a/ev3dev-stretch/debian-stretch-cross-pytools.dockerfile
+++ b/ev3dev-stretch/debian-stretch-cross-pytools.dockerfile
@@ -4,4 +4,5 @@ FROM ev3dev/debian-stretch-cross
 RUN sudo apt-get update && \
     DEBIAN_FRONTEND=noninteractive sudo apt-get install --yes --no-install-recommends \
         python \
-        scons
+        scons && \
+    sudo rm -rf /var/lib/apt/lists/*

--- a/ev3dev-stretch/debian-stretch-cross-pytools.dockerfile
+++ b/ev3dev-stretch/debian-stretch-cross-pytools.dockerfile
@@ -1,7 +1,7 @@
-FROM ev3dev:debian-stretch-cross
+FROM ev3dev/debian-stretch-cross
 
 # Install python tools needed for cross builds
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+RUN sudo apt-get update && \
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install --yes --no-install-recommends \
         python \
         scons


### PR DESCRIPTION
Dockerfile to enable Python tools (python, scons) for ev3dev/debian-stretch-cross